### PR TITLE
chore: config and create aliases for imports

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
-import WindowButton from '../components/WindowButton.astro'
-import TextWithDegradation from '../components/TextWithDegradation.astro'
-import SpeakerCard from '../components/SpeakerCard.astro'
-import { getAllSpeakers } from '../services/speakers.js'
+import WindowButton from '@components/WindowButton.astro'
+import TextWithDegradation from '@components/TextWithDegradation.astro'
+import SpeakerCard from '@components/SpeakerCard.astro'
+import { getAllSpeakers } from '@services/speakers.js'
 
 const speakers = await getAllSpeakers()
 ---

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"],
+      "@services/*":["src/services/*"]
+    }
   }
 }


### PR DESCRIPTION
Added aliases to manage better all imports on components according to [astro's docs](https://docs.astro.build/en/guides/aliases/)