### PR TITLE
Remove deprecated config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,5 +4,5 @@ import tailwind from "@astrojs/tailwind";
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [tailwind({ config: { applyAstroPreset: false, applyBaseStyles: true } })]
+  integrations: [tailwind()]
 });

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  content: ["./src/**/*.{html,js,astro}"],
+  content: ["./src/**/*.{html,js,astro,jsx,ts,tsx}"],
   theme: {
     extend: {
       animation: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,16 @@
 {
   "compilerOptions": {
+    // Enable top-level await and other modern ESM features.
+    "target": "ESNext",
+    "module": "ESNext",
+    // Enable JSON imports.
+    "resolveJsonModule": true,
+    // Enable stricter transpilation for better output.
+    "isolatedModules": true,
+    // Add type definitions for our Vite runtime.
+    "types": ["vite/client"],
+    // Tell TypeScript where your build output is
+    "outDir": "./dist",
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
**Description**
- remove tailwindcss settings that come by default
- add file extensions for jsx,ts and tsx files
- add tsconfig defaults for astro and vite (more information in [astro docs#typescript](https://docs.astro.build/en/guides/typescript/#setup))