### PR TITLE
add eslint for `.astro` files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,26 @@
+module.exports = {
+  env: {
+    node: true,
+    es2022: true,
+    browser: true,
+  },
+  extends: ['eslint:recommended', 'plugin:astro/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  rules: {},
+  overrides: [
+    {
+      files: ["*.astro"],
+      parser: "astro-eslint-parser",
+      parserOptions: {
+        parser: "@typescript-eslint/parser",
+        extraFileExtensions: [".astro"],
+      },
+      rules: {
+        "astro/no-set-html-directive": "error" // prevent XSS attack 
+      },
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -10,11 +10,15 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "format": "prettier -w 'src/**/*.{js,jsx,ts,tsx,astro}'"
+    "format": "prettier -w 'src/**/*.{js,jsx,ts,tsx,astro}'",
+    "lint:eslint": "eslint . --ext .js,.astro"
   },
   "devDependencies": {
     "@astrojs/tailwind": "0.2.2",
+    "@typescript-eslint/parser": "^5.30.5",
     "astro": "1.0.0-beta.63",
+    "eslint": "^8.19.0",
+    "eslint-plugin-astro": "^0.14.0",
     "prettier": "2.7.1",
     "prettier-plugin-astro": "0.1.1",
     "tailwindcss": "3.1.4"

--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -2,7 +2,7 @@
 const {
   avatar = "/peep-67.png",
   speaker = "Muy pronto",
-  description,
+  // description,
   twitter = "#",
   github = "#",
 } = Astro.props;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,5 @@
 ---
-import { getAllSpeakers } from "@services/speakers.js";
+// import { getAllSpeakers } from "@services/speakers.js";
 import Layout from "@layouts/base.astro";
 import Button from "@components/Button.astro";
 import HomeSponsors from "@components/HomeSponsors.astro";
@@ -7,7 +7,7 @@ import HomeSpeakers from "@components/HomeSpeakers.astro";
 import Footer from "@components/Footer.astro";
 import FAQ from "@components/Faq.astro";
 
-const speakers = await getAllSpeakers();
+ // const speakers = await getAllSpeakers();
 ---
 
 <Layout>


### PR DESCRIPTION
**Description**

- add eslint config for `*.astro` files (supports typescript in Astro files)
- add eslint script `npm run lint:eslint`
- run eslint (comment out unused vars)

Note: Feel free to add your favorite eslint rules for `js,jsx,ts,tsx` files and/or plugins. This configuration only references `.astro` files