### PR TITLE
Eslint setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 package-lock.json
+
+# pnpm
+pnpm-lock.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "astro", // Enable .astro
+    "typescript", // Enable .ts
+    "typescriptreact" // Enable .tsx
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
   },
   "devDependencies": {
     "@astrojs/tailwind": "0.2.4",
-    "@typescript-eslint/parser": "^5.30.6",
+    "@typescript-eslint/parser": "^5.31.0",
     "astro": "1.0.0-beta.72",
     "eslint": "^8.20.0",
-    "eslint-plugin-astro": "0.15.0",
+    "eslint-plugin-astro": "0.16.0",
     "prettier": "2.7.1",
     "prettier-plugin-astro": "0.1.1",
     "tailwindcss": "3.1.6"


### PR DESCRIPTION
Esta PR actualiza las versiones de `@typescript-eslint/parser` y `eslint-plugin-astro`, agrega las extensiones necesarias en `.vscode/settings.json` y agrega al `.gitignore` el archivo `pnpm-lock.yaml` para devs que usen pnpm.