### PR TITLE
ignore pnpm-lock.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 # macOS-specific files
 .DS_Store
 package-lock.json
+
+# pnpm
+pnpm-lock.yaml


### PR DESCRIPTION
Esta PR añade `pnpm-lock.yaml` al `.gitignore`.  Útil para devs que utilicen pnpm.