### PR TITLE
Fix: prevent redirect on token refresh

### DIFF
--- a/src/components/LoginButton.tsx
+++ b/src/components/LoginButton.tsx
@@ -45,6 +45,7 @@ export function LoginButton() {
 
 	useEffect(() => {
 		const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+			if (event !== 'SIGNED_IN') return
 			const newUser = extractInfoFrom(session?.user)
       window.location.href = `/ticket?username=${newUser.userName}`
 		})


### PR DESCRIPTION
### Description

If you are on the home page while authenticated and the browser tab lost focus, once you are back on the page it redirects automatically to the ticket page.

### How to reproduce

- Log in and see your miduconf ticket.
- Without logging out, go back to the main page by editing the URL or clicking the `back` button in the browser.
- Switch to another browser tab so the miduconf tab lost the visibility.
- Go back to the miduconf tab and the page will automatically redirect to the ticket page.

### Solution

In the `useEffect` within the `LoginButton` component, added a single line to avoid any logic to be executed unless the event is `SIGNED_IN`.

### Explanation

The `supabase.auth.onAuthStateChange` listener is called when any of the possible events triggers. One of these events is `TOKEN_REFRESHED` which seems to be triggered by the supabase client on every `onvisibilitychange` browser event.
I think the only relevant event here is the `SIGNED_IN` event, otherwise, the listener will do nothing. This way, we are also avoiding useless calls when irrelevant events happen.

NOTE: We can ignore the `SIGNED_OUT` event because we are handling it in the `LogoutButton`. But, in my opinion, it would be better to handle the redirect and to listen to auth state change in a single place, closer to the entry component.
