### PR TITLE
chore: remove comments and set correct types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "compilerOptions": {
-    // Enable top-level await and other modern ESM features.
     "target": "ESNext",
     "module": "ESNext",
-    // Enable JSON imports.
     "resolveJsonModule": true,
-    // Enable stricter transpilation for better output.
     "isolatedModules": true,
-    // Add type definitions for our Vite runtime.
-    "types": ["vite/client", "preact"],
-    // Tell TypeScript where your build output is
+    "types": ["astro/client", "preact"],
     "outDir": "./dist",
     "moduleResolution": "node",
     "jsx": "react-jsx",


### PR DESCRIPTION
Se eliminan los comentarios del `tsconfig.json` y se cambia el type `"vite/client"` por `"astro/client"`