### PR TITLE
Hide scroll bar when menu is activated

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -47,3 +47,29 @@ import MenuIcon from './icons/Menu.astro'
 		</ul>
 	</nav>
 </header>
+
+<script type="module">
+const menuCheckbox = document.getElementById('menu')
+const mediaQuery = window.matchMedia('(min-width: 1024px)') // Breakpoint lg
+
+/** @param {boolean} value */
+function hideOverFlow (value) {
+	if (value) {
+		window.scrollTo(0, 0)
+		document.body.style.overflowY = 'hidden'
+	} else {
+		document.body.style.overflowY = 'auto'
+	}
+}
+
+menuCheckbox.addEventListener('change', (e) =>
+	e.target.checked ? hideOverFlow(true) : hideOverFlow(false)
+)
+
+mediaQuery.addEventListener('change', (e) => {
+	if (e.matches) {
+		hideOverFlow(false)
+		menuCheckbox.checked = false
+	}
+})
+</script>


### PR DESCRIPTION
### Description
When the navigation menu is activated then the scroll bar will be hidden.

![comparison](https://user-images.githubusercontent.com/88288135/185494802-43b92b29-1442-4337-96ef-6c8910d521fd.png)

### Before:
![before (2)](https://user-images.githubusercontent.com/88288135/185490019-3052403c-b5fc-4355-a528-229ddefd522a.gif)

### After:
![after (2)](https://user-images.githubusercontent.com/88288135/185490115-ada6ef4d-787d-4739-a320-6e947003b767.gif)


