### PR TITLE
Check if midudev is live and add animated iframe border

### DIFF
--- a/src/components/Principal.astro
+++ b/src/components/Principal.astro
@@ -18,7 +18,7 @@ import CalendarScriptAndStyles from '@components/CalendarScriptAndStyles.astro'
 			<h4 class='text-sm font-bold tracking-widest text-gray-700'>
 				CONFERENCIA DE PROGRAMACIÓN y DESARROLLO
 			</h4>
-			<div class='mt-10 w-full'>
+			<div id='twitch-embed-parent' class='mt-10 w-full hidden'>
 				<div id='twitch-embed' class='w-full aspect-video'></div>
 			</div>
 			<div class='flex pt-4 text-left gap-x-8'>
@@ -57,12 +57,22 @@ import CalendarScriptAndStyles from '@components/CalendarScriptAndStyles.astro'
 
 <!-- Create a Twitch.Player object. This will render within the placeholder div -->
 <script type='text/javascript'>
-	// eslint-disable-next-line no-new, no-undef
-	new Twitch.Player('twitch-embed', {
-		channel: 'midudev',
-		width: '100%',
-		height: '100%'
-	})
+	fetch('https://midudev-apis.midudev.workers.dev/uptime/midudev')
+		.then((res) => res.json())
+		.then(({ online }) => {
+			if (online) {
+				// eslint-disable-next-line no-new, no-undef
+				new Twitch.Player('twitch-embed', {
+					channel: 'midudev',
+					width: '100%',
+					height: '100%'
+				})
+				document.getElementById('twitch-embed-parent').style.display = 'block'
+			}
+		})
+		.catch(err => {
+			console.error(err)
+		})
 </script>
 
 <script type='module'>

--- a/src/global.css
+++ b/src/global.css
@@ -11,3 +11,23 @@
 		@apply pointer-events-none opacity-100 contrast-100 drop-shadow-4xl;
 	}
 }
+
+#twitch-embed-parent {
+	background: #9046ffc2;
+	padding: 16px;
+	animation: twitch-bg 3s ease infinite;
+	border-radius: 16px;
+	box-shadow: 0px 0px 100px 5px rgba(140, 0, 255, 0.52);
+}
+
+@keyframes twitch-bg {
+	0% {
+		background: #9046ffc2;
+	}
+	50% {
+		background: #d146ff;
+	}
+	100% {
+		background: #9046ffc2;
+	}
+}


### PR DESCRIPTION
Added same behavior and style than [midu.dev](https://midu.dev/) twitch `iframe`:
- It shows the `iframe` only if midudev is live
- The `iframe` has an animated border

The code added is literally a copy of [midu.dev source code](https://github.com/midudev/midu.dev) 😆 

![image](https://user-images.githubusercontent.com/56328053/189989457-76e14b8a-17e1-460e-a8e9-b57f3466624e.png)
![image](https://user-images.githubusercontent.com/56328053/189989623-18f9c322-3109-4096-9937-e1361bdf8f94.png)
