### PR TITLE
fix: Use || instead of ?? as we are receiving empty strings

### DIFF
--- a/src/pages/ticket.js
+++ b/src/pages/ticket.js
@@ -45,7 +45,6 @@ export default function Ticket({ user, ticketNumber, selectedFlavor = 'javascrip
 	const [number, setNumber] = useState(ticketNumber)
 	const [flavorKey, setFlavorKey] = useState(selectedFlavor)
 	const supabase = useSupabaseClient()
-
 	const flavor = FLAVORS[flavorKey]
 
 	const { username, avatar, name } = user
@@ -288,14 +287,12 @@ export const getServerSideProps = async (ctx) => {
 		if (error) console.error(error)
 
 		const { data } = await supabase.from('ticket').select('*').eq('id', session.user.id)
-
-		selectedFlavor = data[0].flavour ?? 'javascript'
-		ticketNumber = data[0].ticket_number ?? 0
+		selectedFlavor = data[0].flavour || 'javascript'
+		ticketNumber = data[0].ticket_number || 0
 	} else {
-		selectedFlavor = data[0].flavour ?? 'javascript'
-		ticketNumber = data[0].ticket_number ?? 0
+		selectedFlavor = data[0].flavour || 'javascript'
+		ticketNumber = data[0].ticket_number || 0
 	}
-
 	return {
 		props: {
 			selectedFlavor,


### PR DESCRIPTION
En mi caso al intentar acceder al ticket el valor de **flavour** venía como empty string por lo que el operador ?? no estaba funcionando, ya que solo funciona con null o undefined (ver mas en [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing).

Usando || podemos usar el default y no enviar un string vacío.