### PR TITLE
Fix header's scroll shadow and add pretty URLs for tickets

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,14 @@ const nextConfig = {
   experimental: {
     esmExternals: false, // THIS IS THE FLAG THAT MATTERS
   },
+  async rewrites() {
+	return [
+		{
+			source: "/ticket/:username",
+			destination: "/?ticket=:username"
+		}
+	]
+  }
 }
 
 module.exports = nextConfig

--- a/src/pages/ticket.js
+++ b/src/pages/ticket.js
@@ -59,7 +59,7 @@ export default function Ticket({ user, ticketNumber, selectedFlavor = 'javascrip
 	const title = 'miduConf - Conferencia de Programación y Tecnología'
 	const description =
 		'¡No te pierdas la miduConf el 13 de SEPTIEMBRE! Charlas para todos los niveles, +256 regalos y premios, ¡y muchas sorpresas!'
-	const url = `https://miduconf.com/?ticket=${username}`
+	const url = `https://miduconf.com/ticket/${username}`
 	const ogImage = `${PREFIX_CDN}/ticket-${number}.jpg?${crypto.randomUUID()}=_buster`
 
 	const handleShare = async () => {
@@ -74,7 +74,7 @@ Conferencia de Programación y Tecnología.
 
 Apunta la fecha: 13 de SEPTIEMBRE
 
-https://miduconf.com/?ticket=${username}`
+https://miduconf.com/ticket/${username}`
 
 		window.open(`${intent}?text=${encodeURIComponent(text)}`)
 	}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,7 +9,7 @@ body {
 
 @keyframes add-shadow {
 	to {
-		box-shadow: 0 5px 5px -3px rgba(255, 255, 255,.25);
+		box-shadow: 0 5px 50px -5px hsla(0, 0%, 100%, .1), 0 0 0 1px hsla(0, 0%, 100%, .10);
 		background: rgba(0, 0, 0, .3);
 	}
 }


### PR DESCRIPTION
This PR fixes the header's shadow applied when scrolling to make it look more natural.

**Current:**
![image](https://github.com/midudev/miduconf-website/assets/7684330/d8e6d272-8335-4322-95a7-386f640d1d91)

**Proposed:**
![image](https://github.com/midudev/miduconf-website/assets/7684330/7089deaf-8579-417b-aeb0-dabab6c10cb5)

Also, it adds pretty URLs for tickets using Next.js rewrites, it still works the same, only URLs changed.
`/?ticket=fredoist` → `/ticket/fredoist`