### PR TITLE
refactor: .env file added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pnpm-debug.log*
 
 # environment variables
 .env.production
+.env
 
 # macOS-specific files
 .DS_Store


### PR DESCRIPTION
The .env was added to the .gitignore, since the environment variables of the .env are public in the repository.