### PR TITLE
fix: speakers country visibility

### DIFF
--- a/src/components/Speakers.tsx
+++ b/src/components/Speakers.tsx
@@ -108,7 +108,7 @@ function Speaker({ name, title, twitter, img, country }) {
 				</header>
 				<footer className='flex items-center justify-between gap-x-2'>
 					<p className='text-xs text-left text-white/60'>{title}</p>
-					<span>{country}</span>
+					<span className=' text-white/60'>{country}</span>
 				</footer>
 			</div>
 		</article>


### PR DESCRIPTION
<h1>In the speakers section the color of the country is changed, since it was not accessible</h1>

Before: 
![image](https://github.com/user-attachments/assets/377b9963-848c-45db-88dc-1d7924596260)

After: 
![image](https://github.com/user-attachments/assets/d7b5c9eb-52f0-4347-8d6d-9477f53c3493)
