### PR TITLE
feat: add padding top to timezone

### DIFF
--- a/src/sections/agenda.tsx
+++ b/src/sections/agenda.tsx
@@ -16,7 +16,7 @@ export const Agenda = () => {
 			<p className='text-xl text-white/80 text-center [text-wrap:balance] mt-4'>
 				Todas las charlas son en directo y en español
 			</p>
-			<div className='w-full mx-auto space-y-4 text-center'>
+			<div className='w-full mx-auto space-y-4 pt-2 text-center'>
 				<span className='inline-flex flex-wrap items-center justify-center px-3 py-1 text-sm font-medium text-white rounded-full bg-sky-950 text-primary-300 shadow-inset shadow-white'>
 					<span className='flex items-center gap-1 mr-1 opacity-75'>
 						<svg


### PR DESCRIPTION
Added a little padding to the top for the timezone component to give it some breathing room.
Before:
![image](https://github.com/user-attachments/assets/9f3346e8-ce6b-4cda-99a1-645e5a448bfc)
After:
![image](https://github.com/user-attachments/assets/612d16e8-3546-4c6e-9f75-956d19d85e60)
