### PR TITLE
Fix: Make Country span tag is readable

### DIFF
--- a/src/components/Speakers.tsx
+++ b/src/components/Speakers.tsx
@@ -108,7 +108,7 @@ function Speaker({ name, title, twitter, img, country }) {
 				</header>
 				<footer className='flex items-center justify-between gap-x-2'>
 					<p className='text-xs text-left text-white/60'>{title}</p>
-					<span>{country}</span>
+					<span className='text-white'>{country}</span>
 				</footer>
 			</div>
 		</article>


### PR DESCRIPTION
Issue: The Country label is not visible of the speakers. [Miduconf page](https://www.miduconf.com/#speakers)
 
Current page: 
![image](https://github.com/user-attachments/assets/9265b067-a8b8-4aa7-906a-4b5468da291b)

Change proposal: 
![image](https://github.com/user-attachments/assets/129809fb-12b7-436e-99dc-03b258928569)
