### PR TITLE
♻️ Fix: menú mobile usa `dvh` en lugar de `vh` para evitar problemas de viewport

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -122,7 +122,7 @@ function Navbar() {
           id={navbarId}
           ref={refNavbarList}
           className={cn(
-            'navbarList animation-ul group clipHidden absolute inset-0 lg:inset-auto h-screen lg:h-auto flex flex-col lg:flex-row justify-end items-end p-5 space-y-spacing-24 bg-palette-background lg:top-[28px] lg:bottom-auto pt-[80px] pb-5 lg:clipVisible lg:bg-transparent lg:p-0 lg:left-1/2 lg:-translate-x-1/2 lg:justify-center lg:items-center lg:space-y-0'
+            'navbarList animation-ul group clipHidden absolute inset-0 lg:inset-auto h-dvh lg:h-auto flex flex-col lg:flex-row justify-end items-end p-5 space-y-spacing-24 bg-palette-background lg:top-[28px] lg:bottom-auto pt-[80px] pb-5 lg:clipVisible lg:bg-transparent lg:p-0 lg:left-1/2 lg:-translate-x-1/2 lg:justify-center lg:items-center lg:space-y-0'
           )}
         >
           {NAV_ITEMS.map(({ href, title }) => (


### PR DESCRIPTION
## ♻️ Fix: menú mobile usa `dvh` en lugar de `vh` para evitar problemas de viewport

### Problema

En algunos navegadores móviles, al usar `100vh` para definir la altura del menú, los controles del navegador (como la barra de direcciones) hacen que parte del menú quede fuera del área visible, impidiendo que el usuario interactúe con ciertos elementos del mismo.

### Solución

Este PR reemplaza el uso de `vh` por `dvh`, que se ajusta dinámicamente al espacio visible en pantalla, resolviendo el problema de accesibilidad y mejorando la experiencia de usuario en dispositivos móviles.

### Cambios realizados

- Reemplazo de `h-screen` por `h-dvh` en el estilo del menú mobile.

### Antes vs Después

| Antes | Después |
|-------|---------|
|![antes-menu-miduconf](https://github.com/user-attachments/assets/6192d76f-33c7-483b-88c9-374efffb756e)|![despues-menumobile-miduconf](https://github.com/user-attachments/assets/1efe7078-cc2f-4d94-abfc-b0467142af79)|
| Parte del menú queda fuera del viewport cuando los controles del navegador están visibles. | El menú se ajusta al área visible del dispositivo, sin importar si los controles están activos. |
